### PR TITLE
Fix chain-sync panic error on multi-part messages

### DIFF
--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
+
 	"github.com/cloudstruct/go-ouroboros-network/block"
 	"github.com/cloudstruct/go-ouroboros-network/muxer"
 	"github.com/cloudstruct/go-ouroboros-network/utils"
-	"io"
 )
 
 const (
@@ -82,7 +83,7 @@ func (c *ChainSync) recvLoop() {
 		// Decode response into generic list until we can determine what type of response it is
 		var resp []interface{}
 		if _, err := utils.CborDecode(c.recvBuffer.Bytes(), &resp); err != nil {
-			if errors.Is(err, io.ErrUnexpectedEOF) {
+			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
 				// This is probably a multi-part message, so we wait until we get more of the message
 				// before trying to process it
 				continue


### PR DESCRIPTION
Hello, 
I was testing out the service locally and got panic error when syncing chain. This PR adds small fix to address the below issue.

## Issue
Panic error exception occuring when multipart chain-sync msg has EOF no response is received from chain-sync message Payload. 
```
xd7, 0xbb, 0x1d, 0xf8, 0x7e, 0x37, 0xaa, 0x2a, 0x53, 0x6c, 0xf8, 0x83, 0x13, 0xd4, 0xf6, 0x8f, 0x7c, 0x2a, 0x34, 0xcd, 0x1a, 0xe0, 0x5a, 0xc2, 0x42, 0x32}}, BlockNumber:0x202f}
panic: runtime error: index out of range [0] with length 0

goroutine 24 [running]:
github.com/cloudstruct/go-ouroboros-network/protocol/chainsync.(*ChainSync).recvLoop(0xc00009c320)
        ~/go-ouroboros-network/protocol/chainsync/chainsync.go:93 +0x3cc
created by github.com/cloudstruct/go-ouroboros-network/protocol/chainsync.New
        ~/go-ouroboros-network/protocol/chainsync/chainsync.go:72 +0x132

```

## Solution
Add additional EOF error handling to check if error is also normal/expected `EOF`.


