### PR TITLE
Minor refactor to make library more composable

### DIFF
--- a/protocol/blockfetch/messages.go
+++ b/protocol/blockfetch/messages.go
@@ -20,17 +20,17 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	var ret protocol.Message
 	switch msgType {
 	case MESSAGE_TYPE_REQUEST_RANGE:
-		ret = &msgRequestRange{}
+		ret = &MsgRequestRange{}
 	case MESSAGE_TYPE_CLIENT_DONE:
-		ret = &msgClientDone{}
+		ret = &MsgClientDone{}
 	case MESSAGE_TYPE_START_BATCH:
-		ret = &msgStartBatch{}
+		ret = &MsgStartBatch{}
 	case MESSAGE_TYPE_NO_BLOCKS:
-		ret = &msgNoBlocks{}
+		ret = &MsgNoBlocks{}
 	case MESSAGE_TYPE_BLOCK:
-		ret = &msgBlock{}
+		ret = &MsgBlock{}
 	case MESSAGE_TYPE_BATCH_DONE:
-		ret = &msgBatchDone{}
+		ret = &MsgBatchDone{}
 	}
 	if _, err := utils.CborDecode(data, ret); err != nil {
 		return nil, fmt.Errorf("%s: decode error: %s", PROTOCOL_NAME, err)
@@ -42,14 +42,14 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	return ret, nil
 }
 
-type msgRequestRange struct {
+type MsgRequestRange struct {
 	protocol.MessageBase
 	Start interface{} //point
 	End   interface{} //point
 }
 
-func newMsgRequestRange(start interface{}, end interface{}) *msgRequestRange {
-	m := &msgRequestRange{
+func NewMsgRequestRange(start interface{}, end interface{}) *MsgRequestRange {
+	m := &MsgRequestRange{
 		MessageBase: protocol.MessageBase{
 			MessageType: MESSAGE_TYPE_REQUEST_RANGE,
 		},
@@ -59,12 +59,12 @@ func newMsgRequestRange(start interface{}, end interface{}) *msgRequestRange {
 	return m
 }
 
-type msgClientDone struct {
+type MsgClientDone struct {
 	protocol.MessageBase
 }
 
-func newMsgClientDone() *msgClientDone {
-	m := &msgClientDone{
+func NewMsgClientDone() *MsgClientDone {
+	m := &MsgClientDone{
 		MessageBase: protocol.MessageBase{
 			MessageType: MESSAGE_TYPE_CLIENT_DONE,
 		},
@@ -72,20 +72,20 @@ func newMsgClientDone() *msgClientDone {
 	return m
 }
 
-type msgStartBatch struct {
+type MsgStartBatch struct {
 	protocol.MessageBase
 }
 
-type msgNoBlocks struct {
+type MsgNoBlocks struct {
 	protocol.MessageBase
 }
 
-type msgBlock struct {
+type MsgBlock struct {
 	protocol.MessageBase
 	WrappedBlock []byte
 }
 
-type msgBatchDone struct {
+type MsgBatchDone struct {
 	protocol.MessageBase
 }
 
@@ -97,7 +97,7 @@ type point struct {
 }
 */
 
-type wrappedBlock struct {
+type WrappedBlock struct {
 	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
 	_        struct{} `cbor:",toarray"`
 	Type     uint

--- a/protocol/handshake/handshake.go
+++ b/protocol/handshake/handshake.go
@@ -19,7 +19,7 @@ var (
 	STATE_DONE    = protocol.NewState(3, "Done")
 )
 
-var stateMap = protocol.StateMap{
+var StateMap = protocol.StateMap{
 	STATE_PROPOSE: protocol.StateMapEntry{
 		Agency: protocol.AGENCY_CLIENT,
 		Transitions: []protocol.StateTransition{
@@ -68,7 +68,7 @@ func New(options protocol.ProtocolOptions, allowedVersions []uint16) *Handshake 
 		Role:                options.Role,
 		MessageHandlerFunc:  h.handleMessage,
 		MessageFromCborFunc: NewMsgFromCbor,
-		StateMap:            stateMap,
+		StateMap:            StateMap,
 		InitialState:        STATE_PROPOSE,
 	}
 	h.proto = protocol.New(protoConfig)
@@ -100,12 +100,12 @@ func (h *Handshake) ProposeVersions(versions []uint16, networkMagic uint32) erro
 			versionMap[version] = networkMagic
 		}
 	}
-	msg := newMsgProposeVersions(versionMap)
+	msg := NewMsgProposeVersions(versionMap)
 	return h.proto.SendMessage(msg, false)
 }
 
 func (h *Handshake) handleProposeVersions(msgGeneric protocol.Message) error {
-	msg := msgGeneric.(*msgProposeVersions)
+	msg := msgGeneric.(*MsgProposeVersions)
 	var highestVersion uint16
 	var versionData interface{}
 	for proposedVersion := range msg.VersionMap {
@@ -120,7 +120,7 @@ func (h *Handshake) handleProposeVersions(msgGeneric protocol.Message) error {
 		}
 	}
 	if highestVersion > 0 {
-		resp := newMsgAcceptVersion(highestVersion, versionData)
+		resp := NewMsgAcceptVersion(highestVersion, versionData)
 		return h.proto.SendMessage(resp, true)
 	} else {
 		// TODO: handle failures
@@ -130,14 +130,14 @@ func (h *Handshake) handleProposeVersions(msgGeneric protocol.Message) error {
 }
 
 func (h *Handshake) handleAcceptVersion(msgGeneric protocol.Message) error {
-	msg := msgGeneric.(*msgAcceptVersion)
+	msg := msgGeneric.(*MsgAcceptVersion)
 	h.Version = msg.Version
 	h.Finished <- true
 	return nil
 }
 
 func (h *Handshake) handleRefuse(msgGeneric protocol.Message) error {
-	msg := msgGeneric.(*msgRefuse)
+	msg := msgGeneric.(*MsgRefuse)
 	var err error
 	switch msg.Reason[0].(uint64) {
 	case REFUSE_REASON_VERSION_MISMATCH:

--- a/protocol/handshake/messages.go
+++ b/protocol/handshake/messages.go
@@ -20,11 +20,11 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	var ret protocol.Message
 	switch msgType {
 	case MESSAGE_TYPE_PROPOSE_VERSIONS:
-		ret = &msgProposeVersions{}
+		ret = &MsgProposeVersions{}
 	case MESSAGE_TYPE_ACCEPT_VERSION:
-		ret = &msgAcceptVersion{}
+		ret = &MsgAcceptVersion{}
 	case MESSAGE_TYPE_REFUSE:
-		ret = &msgRefuse{}
+		ret = &MsgRefuse{}
 	}
 	if _, err := utils.CborDecode(data, ret); err != nil {
 		return nil, fmt.Errorf("%s: decode error: %s", PROTOCOL_NAME, err)
@@ -36,13 +36,13 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	return ret, nil
 }
 
-type msgProposeVersions struct {
+type MsgProposeVersions struct {
 	protocol.MessageBase
 	VersionMap map[uint16]interface{}
 }
 
-func newMsgProposeVersions(versionMap map[uint16]interface{}) *msgProposeVersions {
-	m := &msgProposeVersions{
+func NewMsgProposeVersions(versionMap map[uint16]interface{}) *MsgProposeVersions {
+	m := &MsgProposeVersions{
 		MessageBase: protocol.MessageBase{
 			MessageType: MESSAGE_TYPE_PROPOSE_VERSIONS,
 		},
@@ -51,14 +51,14 @@ func newMsgProposeVersions(versionMap map[uint16]interface{}) *msgProposeVersion
 	return m
 }
 
-type msgAcceptVersion struct {
+type MsgAcceptVersion struct {
 	protocol.MessageBase
 	Version     uint16
 	VersionData interface{}
 }
 
-func newMsgAcceptVersion(version uint16, versionData interface{}) *msgAcceptVersion {
-	m := &msgAcceptVersion{
+func NewMsgAcceptVersion(version uint16, versionData interface{}) *MsgAcceptVersion {
+	m := &MsgAcceptVersion{
 		MessageBase: protocol.MessageBase{
 			MessageType: MESSAGE_TYPE_ACCEPT_VERSION,
 		},
@@ -68,7 +68,7 @@ func newMsgAcceptVersion(version uint16, versionData interface{}) *msgAcceptVers
 	return m
 }
 
-type msgRefuse struct {
+type MsgRefuse struct {
 	protocol.MessageBase
 	Reason []interface{}
 }

--- a/protocol/keepalive/keepalive.go
+++ b/protocol/keepalive/keepalive.go
@@ -20,7 +20,7 @@ var (
 	STATE_DONE   = protocol.NewState(3, "Done")
 )
 
-var stateMap = protocol.StateMap{
+var StateMap = protocol.StateMap{
 	STATE_CLIENT: protocol.StateMapEntry{
 		Agency: protocol.AGENCY_CLIENT,
 		Transitions: []protocol.StateTransition{
@@ -78,7 +78,7 @@ func New(options protocol.ProtocolOptions, callbackConfig *KeepAliveCallbackConf
 		Role:                options.Role,
 		MessageHandlerFunc:  k.messageHandler,
 		MessageFromCborFunc: NewMsgFromCbor,
-		StateMap:            stateMap,
+		StateMap:            StateMap,
 		InitialState:        STATE_CLIENT,
 	}
 	k.proto = protocol.New(protoConfig)
@@ -117,24 +117,24 @@ func (k *KeepAlive) Stop() {
 }
 
 func (k *KeepAlive) KeepAlive(cookie uint16) error {
-	msg := newMsgKeepAlive(cookie)
+	msg := NewMsgKeepAlive(cookie)
 	return k.proto.SendMessage(msg, false)
 }
 
 func (k *KeepAlive) handleKeepAlive(msgGeneric protocol.Message) error {
-	msg := msgGeneric.(*msgKeepAlive)
+	msg := msgGeneric.(*MsgKeepAlive)
 	if k.callbackConfig != nil && k.callbackConfig.KeepAliveFunc != nil {
 		// Call the user callback function
 		return k.callbackConfig.KeepAliveFunc(msg.Cookie)
 	} else {
 		// Send the keep-alive response
-		resp := newMsgKeepAliveResponse(msg.Cookie)
+		resp := NewMsgKeepAliveResponse(msg.Cookie)
 		return k.proto.SendMessage(resp, true)
 	}
 }
 
 func (k *KeepAlive) handleKeepAliveResponse(msgGeneric protocol.Message) error {
-	msg := msgGeneric.(*msgKeepAliveResponse)
+	msg := msgGeneric.(*MsgKeepAliveResponse)
 	// Start the timer again if we had one previously
 	if k.timer != nil {
 		defer k.Start()

--- a/protocol/keepalive/messages.go
+++ b/protocol/keepalive/messages.go
@@ -16,11 +16,11 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	var ret protocol.Message
 	switch msgType {
 	case MESSAGE_TYPE_KEEP_ALIVE:
-		ret = &msgKeepAlive{}
+		ret = &MsgKeepAlive{}
 	case MESSAGE_TYPE_KEEP_ALIVE_RESPONSE:
-		ret = &msgKeepAliveResponse{}
+		ret = &MsgKeepAliveResponse{}
 	case MESSAGE_TYPE_DONE:
-		ret = &msgDone{}
+		ret = &MsgDone{}
 	}
 	if _, err := utils.CborDecode(data, ret); err != nil {
 		return nil, fmt.Errorf("%s: decode error: %s", PROTOCOL_NAME, err)
@@ -32,13 +32,13 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	return ret, nil
 }
 
-type msgKeepAlive struct {
+type MsgKeepAlive struct {
 	protocol.MessageBase
 	Cookie uint16
 }
 
-func newMsgKeepAlive(cookie uint16) *msgKeepAlive {
-	msg := &msgKeepAlive{
+func NewMsgKeepAlive(cookie uint16) *MsgKeepAlive {
+	msg := &MsgKeepAlive{
 		MessageBase: protocol.MessageBase{
 			MessageType: MESSAGE_TYPE_KEEP_ALIVE,
 		},
@@ -47,13 +47,13 @@ func newMsgKeepAlive(cookie uint16) *msgKeepAlive {
 	return msg
 }
 
-type msgKeepAliveResponse struct {
+type MsgKeepAliveResponse struct {
 	protocol.MessageBase
 	Cookie uint16
 }
 
-func newMsgKeepAliveResponse(cookie uint16) *msgKeepAliveResponse {
-	msg := &msgKeepAliveResponse{
+func NewMsgKeepAliveResponse(cookie uint16) *MsgKeepAliveResponse {
+	msg := &MsgKeepAliveResponse{
 		MessageBase: protocol.MessageBase{
 			MessageType: MESSAGE_TYPE_KEEP_ALIVE_RESPONSE,
 		},
@@ -62,6 +62,6 @@ func newMsgKeepAliveResponse(cookie uint16) *msgKeepAliveResponse {
 	return msg
 }
 
-type msgDone struct {
+type MsgDone struct {
 	protocol.MessageBase
 }

--- a/protocol/localtxsubmission/localtxsubmission.go
+++ b/protocol/localtxsubmission/localtxsubmission.go
@@ -16,7 +16,7 @@ var (
 	STATE_DONE = protocol.NewState(3, "Done")
 )
 
-var stateMap = protocol.StateMap{
+var StateMap = protocol.StateMap{
 	STATE_IDLE: protocol.StateMapEntry{
 		Agency: protocol.AGENCY_CLIENT,
 		Transitions: []protocol.StateTransition{
@@ -75,7 +75,7 @@ func New(options protocol.ProtocolOptions, callbackConfig *CallbackConfig) *Loca
 		Role:                options.Role,
 		MessageHandlerFunc:  l.messageHandler,
 		MessageFromCborFunc: NewMsgFromCbor,
-		StateMap:            stateMap,
+		StateMap:            StateMap,
 		InitialState:        STATE_IDLE,
 	}
 	l.proto = protocol.New(protoConfig)
@@ -100,12 +100,12 @@ func (l *LocalTxSubmission) messageHandler(msg protocol.Message) error {
 }
 
 func (l *LocalTxSubmission) SubmitTx(eraId uint16, tx []byte) error {
-	msg := newMsgSubmitTx(eraId, tx)
+	msg := NewMsgSubmitTx(eraId, tx)
 	return l.proto.SendMessage(msg, false)
 }
 
 func (l *LocalTxSubmission) Done(tx interface{}) error {
-	msg := newMsgDone()
+	msg := NewMsgDone()
 	return l.proto.SendMessage(msg, false)
 }
 
@@ -113,7 +113,7 @@ func (l *LocalTxSubmission) handleSubmitTx(msgGeneric protocol.Message) error {
 	if l.callbackConfig.SubmitTxFunc == nil {
 		return fmt.Errorf("received local-tx-submission SubmitTx message but no callback function is defined")
 	}
-	msg := msgGeneric.(*msgSubmitTx)
+	msg := msgGeneric.(*MsgSubmitTx)
 	// Call the user callback function
 	return l.callbackConfig.SubmitTxFunc(msg.Transaction)
 }
@@ -130,7 +130,7 @@ func (l *LocalTxSubmission) handleRejectTx(msgGeneric protocol.Message) error {
 	if l.callbackConfig.RejectTxFunc == nil {
 		return fmt.Errorf("received local-tx-submission RejectTx message but no callback function is defined")
 	}
-	msg := msgGeneric.(*msgRejectTx)
+	msg := msgGeneric.(*MsgRejectTx)
 	// Call the user callback function
 	return l.callbackConfig.RejectTxFunc(msg.Reason)
 }

--- a/protocol/localtxsubmission/messages.go
+++ b/protocol/localtxsubmission/messages.go
@@ -18,13 +18,13 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	var ret protocol.Message
 	switch msgType {
 	case MESSAGE_TYPE_SUBMIT_TX:
-		ret = &msgSubmitTx{}
+		ret = &MsgSubmitTx{}
 	case MESSAGE_TYPE_ACCEPT_TX:
-		ret = &msgAcceptTx{}
+		ret = &MsgAcceptTx{}
 	case MESSAGE_TYPE_REJECT_TX:
-		ret = &msgRejectTx{}
+		ret = &MsgRejectTx{}
 	case MESSAGE_TYPE_DONE:
-		ret = &msgDone{}
+		ret = &MsgDone{}
 	}
 	if _, err := utils.CborDecode(data, ret); err != nil {
 		return nil, fmt.Errorf("%s: decode error: %s", PROTOCOL_NAME, err)
@@ -36,24 +36,24 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	return ret, nil
 }
 
-type msgSubmitTx struct {
+type MsgSubmitTx struct {
 	protocol.MessageBase
-	Transaction msgSubmitTxTransaction
+	Transaction MsgSubmitTxTransaction
 }
 
-type msgSubmitTxTransaction struct {
+type MsgSubmitTxTransaction struct {
 	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
 	_     struct{} `cbor:",toarray"`
 	EraId uint16
 	Raw   cbor.Tag
 }
 
-func newMsgSubmitTx(eraId uint16, tx []byte) *msgSubmitTx {
-	m := &msgSubmitTx{
+func NewMsgSubmitTx(eraId uint16, tx []byte) *MsgSubmitTx {
+	m := &MsgSubmitTx{
 		MessageBase: protocol.MessageBase{
 			MessageType: MESSAGE_TYPE_SUBMIT_TX,
 		},
-		Transaction: msgSubmitTxTransaction{
+		Transaction: MsgSubmitTxTransaction{
 			EraId: eraId,
 			Raw: cbor.Tag{
 				// Wrapped CBOR
@@ -65,21 +65,21 @@ func newMsgSubmitTx(eraId uint16, tx []byte) *msgSubmitTx {
 	return m
 }
 
-type msgAcceptTx struct {
+type MsgAcceptTx struct {
 	protocol.MessageBase
 }
 
-type msgRejectTx struct {
+type MsgRejectTx struct {
 	protocol.MessageBase
 	Reason interface{}
 }
 
-type msgDone struct {
+type MsgDone struct {
 	protocol.MessageBase
 }
 
-func newMsgDone() *msgDone {
-	m := &msgDone{
+func NewMsgDone() *MsgDone {
+	m := &MsgDone{
 		MessageBase: protocol.MessageBase{
 			MessageType: MESSAGE_TYPE_DONE,
 		},


### PR DESCRIPTION
* export protocol message types and "new" functions
* export protocol state maps
* use a wrapper function to denote NtN vs. NtC in chain-sync when
  parsing messages from CBOR