### PR TITLE
Implement local-state-query mini-protocol (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ but the node-to-node protocols will also be implemented in time.
 | Name | Status |
 | --- | --- |
 | Handshake | Implemented |
-| Chain-Sync | Implemented |
-| Block-Fetch | Implemented |
-| TxSubmission | Not Implemented |
-| Local TxSubmission | Implemented |
-| Local State Query | Not Implemented |
-| Keep-Alive | Implemented |
+| ChainSync | Implemented |
+| BlockFetch | Implemented |
+| TxSubmission2 | Not Implemented |
+| LocalTxSubmission | Implemented |
+| LocalStateQuery | Partly Implemented |
+| KeepAlive | Implemented |
+| LocalTxMonitor | Not Implemented |
 
 ## Testing
 

--- a/ouroboros.go
+++ b/ouroboros.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloudstruct/go-ouroboros-network/protocol/chainsync"
 	"github.com/cloudstruct/go-ouroboros-network/protocol/handshake"
 	"github.com/cloudstruct/go-ouroboros-network/protocol/keepalive"
+	"github.com/cloudstruct/go-ouroboros-network/protocol/localstatequery"
 	"github.com/cloudstruct/go-ouroboros-network/protocol/localtxsubmission"
 	"net"
 )
@@ -31,6 +32,8 @@ type Ouroboros struct {
 	keepAliveCallbackConfig         *keepalive.KeepAliveCallbackConfig
 	LocalTxSubmission               *localtxsubmission.LocalTxSubmission
 	localTxSubmissionCallbackConfig *localtxsubmission.CallbackConfig
+	LocalStateQuery                 *localstatequery.LocalStateQuery
+	localStateQueryCallbackConfig   *localstatequery.CallbackConfig
 }
 
 type OuroborosOptions struct {
@@ -45,6 +48,7 @@ type OuroborosOptions struct {
 	BlockFetchCallbackConfig        *blockfetch.BlockFetchCallbackConfig
 	KeepAliveCallbackConfig         *keepalive.KeepAliveCallbackConfig
 	LocalTxSubmissionCallbackConfig *localtxsubmission.CallbackConfig
+	LocalStateQueryCallbackConfig   *localstatequery.CallbackConfig
 }
 
 func New(options *OuroborosOptions) (*Ouroboros, error) {
@@ -57,6 +61,7 @@ func New(options *OuroborosOptions) (*Ouroboros, error) {
 		blockFetchCallbackConfig:        options.BlockFetchCallbackConfig,
 		keepAliveCallbackConfig:         options.KeepAliveCallbackConfig,
 		localTxSubmissionCallbackConfig: options.LocalTxSubmissionCallbackConfig,
+		localStateQueryCallbackConfig:   options.LocalStateQueryCallbackConfig,
 		ErrorChan:                       options.ErrorChan,
 		sendKeepAlives:                  options.SendKeepAlives,
 		delayMuxerStart:                 options.DelayMuxerStart,
@@ -140,6 +145,7 @@ func (o *Ouroboros) setupConnection() error {
 		protoOptions.Mode = protocol.ProtocolModeNodeToClient
 		o.ChainSync = chainsync.New(protoOptions, o.chainSyncCallbackConfig)
 		o.LocalTxSubmission = localtxsubmission.New(protoOptions, o.localTxSubmissionCallbackConfig)
+		o.LocalStateQuery = localstatequery.New(protoOptions, o.localStateQueryCallbackConfig)
 	}
 	if !o.delayMuxerStart {
 		o.muxer.Start()

--- a/protocol/localstatequery/localstatequery.go
+++ b/protocol/localstatequery/localstatequery.go
@@ -1,0 +1,242 @@
+package localstatequery
+
+import (
+	"fmt"
+	"github.com/cloudstruct/go-ouroboros-network/protocol"
+)
+
+const (
+	PROTOCOL_NAME        = "local-state-query"
+	PROTOCOL_ID   uint16 = 7
+)
+
+var (
+	STATE_IDLE      = protocol.NewState(1, "Idle")
+	STATE_ACQUIRING = protocol.NewState(2, "Acquiring")
+	STATE_ACQUIRED  = protocol.NewState(3, "Acquired")
+	STATE_QUERYING  = protocol.NewState(4, "Querying")
+	STATE_DONE      = protocol.NewState(5, "Done")
+)
+
+var StateMap = protocol.StateMap{
+	STATE_IDLE: protocol.StateMapEntry{
+		Agency: protocol.AGENCY_SERVER,
+		Transitions: []protocol.StateTransition{
+			{
+				MsgType:  MESSAGE_TYPE_ACQUIRE,
+				NewState: STATE_ACQUIRING,
+			},
+			{
+				MsgType:  MESSAGE_TYPE_ACQUIRE_NO_POINT,
+				NewState: STATE_ACQUIRING,
+			},
+			{
+				MsgType:  MESSAGE_TYPE_DONE,
+				NewState: STATE_DONE,
+			},
+		},
+	},
+	STATE_ACQUIRING: protocol.StateMapEntry{
+		Agency: protocol.AGENCY_CLIENT,
+		Transitions: []protocol.StateTransition{
+			{
+				MsgType:  MESSAGE_TYPE_FAILURE,
+				NewState: STATE_IDLE,
+			},
+			{
+				MsgType:  MESSAGE_TYPE_ACQUIRED,
+				NewState: STATE_ACQUIRED,
+			},
+		},
+	},
+	STATE_ACQUIRED: protocol.StateMapEntry{
+		Agency: protocol.AGENCY_SERVER,
+		Transitions: []protocol.StateTransition{
+			{
+				MsgType:  MESSAGE_TYPE_QUERY,
+				NewState: STATE_QUERYING,
+			},
+			{
+				MsgType:  MESSAGE_TYPE_REACQUIRE,
+				NewState: STATE_ACQUIRING,
+			},
+			{
+				MsgType:  MESSAGE_TYPE_REACQUIRE_NO_POINT,
+				NewState: STATE_ACQUIRING,
+			},
+			{
+				MsgType:  MESSAGE_TYPE_RELEASE,
+				NewState: STATE_IDLE,
+			},
+		},
+	},
+	STATE_QUERYING: protocol.StateMapEntry{
+		Agency: protocol.AGENCY_CLIENT,
+		Transitions: []protocol.StateTransition{
+			{
+				MsgType:  MESSAGE_TYPE_RESULT,
+				NewState: STATE_ACQUIRED,
+			},
+		},
+	},
+	STATE_DONE: protocol.StateMapEntry{
+		Agency: protocol.AGENCY_NONE,
+	},
+}
+
+type LocalStateQuery struct {
+	proto          *protocol.Protocol
+	callbackConfig *CallbackConfig
+}
+
+type CallbackConfig struct {
+	AcquireFunc   AcquireFunc
+	AcquiredFunc  AcquiredFunc
+	FailureFunc   FailureFunc
+	QueryFunc     QueryFunc
+	ResultFunc    ResultFunc
+	ReleaseFunc   ReleaseFunc
+	ReAcquireFunc ReAcquireFunc
+	DoneFunc      DoneFunc
+}
+
+// Callback function types
+// TODO: update callbacks
+type AcquireFunc func(interface{}) error
+type AcquiredFunc func() error
+type FailureFunc func(interface{}) error
+type QueryFunc func(interface{}) error
+type ResultFunc func(interface{}) error
+type ReleaseFunc func() error
+type ReAcquireFunc func(interface{}) error
+type DoneFunc func() error
+
+func New(options protocol.ProtocolOptions, callbackConfig *CallbackConfig) *LocalStateQuery {
+	l := &LocalStateQuery{
+		callbackConfig: callbackConfig,
+	}
+	protoConfig := protocol.ProtocolConfig{
+		Name:                PROTOCOL_NAME,
+		ProtocolId:          PROTOCOL_ID,
+		Muxer:               options.Muxer,
+		ErrorChan:           options.ErrorChan,
+		Mode:                options.Mode,
+		Role:                options.Role,
+		MessageHandlerFunc:  l.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateMap:            StateMap,
+		InitialState:        STATE_IDLE,
+	}
+	l.proto = protocol.New(protoConfig)
+	return l
+}
+
+func (l *LocalStateQuery) messageHandler(msg protocol.Message, isResponse bool) error {
+	var err error
+	switch msg.Type() {
+	case MESSAGE_TYPE_ACQUIRE:
+		err = l.handleAcquire(msg)
+	case MESSAGE_TYPE_ACQUIRED:
+		err = l.handleAcquired()
+	case MESSAGE_TYPE_FAILURE:
+		err = l.handleFailure(msg)
+	case MESSAGE_TYPE_QUERY:
+		err = l.handleQuery(msg)
+	case MESSAGE_TYPE_RESULT:
+		err = l.handleResult(msg)
+	case MESSAGE_TYPE_RELEASE:
+		err = l.handleRelease()
+	case MESSAGE_TYPE_REACQUIRE:
+		err = l.handleReAcquire(msg)
+	case MESSAGE_TYPE_ACQUIRE_NO_POINT:
+		err = l.handleAcquire(msg)
+	case MESSAGE_TYPE_REACQUIRE_NO_POINT:
+		err = l.handleReAcquire(msg)
+	case MESSAGE_TYPE_DONE:
+		err = l.handleDone()
+	default:
+		err = fmt.Errorf("%s: received unexpected message type %d", PROTOCOL_NAME, msg.Type())
+	}
+	return err
+}
+
+func (l *LocalStateQuery) handleAcquire(msg protocol.Message) error {
+	if l.callbackConfig.AcquireFunc == nil {
+		return fmt.Errorf("received local-state-query Acquire message but no callback function is defined")
+	}
+	switch msgAcquire := msg.(type) {
+	case *MsgAcquire:
+		// Call the user callback function
+		return l.callbackConfig.AcquireFunc(msgAcquire.Point)
+	case *MsgAcquireNoPoint:
+		// Call the user callback function
+		return l.callbackConfig.AcquireFunc(nil)
+	}
+	return nil
+}
+
+func (l *LocalStateQuery) handleAcquired() error {
+	if l.callbackConfig.AcquiredFunc == nil {
+		return fmt.Errorf("received local-state-query Acquired message but no callback function is defined")
+	}
+	// Call the user callback function
+	return l.callbackConfig.AcquiredFunc()
+}
+
+func (l *LocalStateQuery) handleFailure(msg protocol.Message) error {
+	if l.callbackConfig.FailureFunc == nil {
+		return fmt.Errorf("received local-state-query Failure message but no callback function is defined")
+	}
+	msgFailure := msg.(*MsgFailure)
+	// Call the user callback function
+	return l.callbackConfig.FailureFunc(msgFailure.Failure)
+}
+
+func (l *LocalStateQuery) handleQuery(msg protocol.Message) error {
+	if l.callbackConfig.QueryFunc == nil {
+		return fmt.Errorf("received local-state-query Query message but no callback function is defined")
+	}
+	msgQuery := msg.(*MsgQuery)
+	// Call the user callback function
+	return l.callbackConfig.QueryFunc(msgQuery.Query)
+}
+
+func (l *LocalStateQuery) handleResult(msg protocol.Message) error {
+	if l.callbackConfig.ResultFunc == nil {
+		return fmt.Errorf("received local-state-query Result message but no callback function is defined")
+	}
+	msgResult := msg.(*MsgResult)
+	// Call the user callback function
+	return l.callbackConfig.ResultFunc(msgResult.Result)
+}
+
+func (l *LocalStateQuery) handleRelease() error {
+	if l.callbackConfig.ReleaseFunc == nil {
+		return fmt.Errorf("received local-state-query Release message but no callback function is defined")
+	}
+	// Call the user callback function
+	return l.callbackConfig.ReleaseFunc()
+}
+
+func (l *LocalStateQuery) handleReAcquire(msg protocol.Message) error {
+	if l.callbackConfig.ReAcquireFunc == nil {
+		return fmt.Errorf("received local-state-query ReAcquire message but no callback function is defined")
+	}
+	switch msgReAcquire := msg.(type) {
+	case *MsgReAcquire:
+		// Call the user callback function
+		return l.callbackConfig.ReAcquireFunc(msgReAcquire.Point)
+	case *MsgReAcquireNoPoint:
+		// Call the user callback function
+		return l.callbackConfig.ReAcquireFunc(nil)
+	}
+	return nil
+}
+
+func (l *LocalStateQuery) handleDone() error {
+	if l.callbackConfig.DoneFunc == nil {
+		return fmt.Errorf("received local-state-query Done message but no callback function is defined")
+	}
+	// Call the user callback function
+	return l.callbackConfig.DoneFunc()
+}

--- a/protocol/localstatequery/messages.go
+++ b/protocol/localstatequery/messages.go
@@ -1,0 +1,217 @@
+package localstatequery
+
+import (
+	"fmt"
+	"github.com/cloudstruct/go-ouroboros-network/protocol"
+	"github.com/cloudstruct/go-ouroboros-network/utils"
+	"github.com/fxamacker/cbor/v2"
+)
+
+const (
+	MESSAGE_TYPE_ACQUIRE            = 0
+	MESSAGE_TYPE_ACQUIRED           = 1
+	MESSAGE_TYPE_FAILURE            = 2
+	MESSAGE_TYPE_QUERY              = 3
+	MESSAGE_TYPE_RESULT             = 4
+	MESSAGE_TYPE_RELEASE            = 5
+	MESSAGE_TYPE_REACQUIRE          = 6
+	MESSAGE_TYPE_DONE               = 7
+	MESSAGE_TYPE_ACQUIRE_NO_POINT   = 8
+	MESSAGE_TYPE_REACQUIRE_NO_POINT = 9
+
+	ACQUIRE_FAILURE_POINT_TOO_OLD      = 0
+	ACQUIRE_FAILURE_POINT_NOT_ON_CHAIN = 1
+)
+
+func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
+	var ret protocol.Message
+	switch msgType {
+	case MESSAGE_TYPE_ACQUIRE:
+		ret = &MsgAcquire{}
+	case MESSAGE_TYPE_ACQUIRED:
+		ret = &MsgAcquired{}
+	case MESSAGE_TYPE_FAILURE:
+		ret = &MsgFailure{}
+	case MESSAGE_TYPE_QUERY:
+		ret = &MsgQuery{}
+	case MESSAGE_TYPE_RESULT:
+		ret = &MsgResult{}
+	case MESSAGE_TYPE_RELEASE:
+		ret = &MsgRelease{}
+	case MESSAGE_TYPE_REACQUIRE:
+		ret = &MsgReAcquire{}
+	case MESSAGE_TYPE_ACQUIRE_NO_POINT:
+		ret = &MsgAcquireNoPoint{}
+	case MESSAGE_TYPE_REACQUIRE_NO_POINT:
+		ret = &MsgReAcquireNoPoint{}
+	case MESSAGE_TYPE_DONE:
+		ret = &MsgDone{}
+	}
+	if _, err := utils.CborDecode(data, ret); err != nil {
+		return nil, fmt.Errorf("%s: decode error: %s", PROTOCOL_NAME, err)
+	}
+	if ret != nil {
+		// Store the raw message CBOR
+		ret.SetCbor(data)
+	}
+	return ret, nil
+}
+
+type MsgAcquire struct {
+	protocol.MessageBase
+	Point Point
+}
+
+func NewMsgAcquire(point Point) *MsgAcquire {
+	m := &MsgAcquire{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_ACQUIRE,
+		},
+		Point: point,
+	}
+	return m
+}
+
+type MsgAcquireNoPoint struct {
+	protocol.MessageBase
+}
+
+func NewMsgAcquireNoPoint() *MsgAcquireNoPoint {
+	m := &MsgAcquireNoPoint{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_ACQUIRE_NO_POINT,
+		},
+	}
+	return m
+}
+
+type MsgAcquired struct {
+	protocol.MessageBase
+}
+
+func NewMsgAcquired() *MsgAcquired {
+	m := &MsgAcquired{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_ACQUIRED,
+		},
+	}
+	return m
+}
+
+type MsgFailure struct {
+	protocol.MessageBase
+	Failure uint8
+}
+
+func NewMsgFailure(failure uint8) *MsgFailure {
+	m := &MsgFailure{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_FAILURE,
+		},
+		Failure: failure,
+	}
+	return m
+}
+
+type MsgQuery struct {
+	protocol.MessageBase
+	Query interface{}
+}
+
+func NewMsgQuery(query interface{}) *MsgQuery {
+	m := &MsgQuery{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_QUERY,
+		},
+		Query: query,
+	}
+	return m
+}
+
+type MsgResult struct {
+	protocol.MessageBase
+	Result interface{}
+}
+
+func NewMsgResult(result interface{}) *MsgResult {
+	m := &MsgResult{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_RESULT,
+		},
+		Result: result,
+	}
+	return m
+}
+
+type MsgRelease struct {
+	protocol.MessageBase
+}
+
+func NewMsgRelease() *MsgRelease {
+	m := &MsgRelease{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_RELEASE,
+		},
+	}
+	return m
+}
+
+type MsgReAcquire struct {
+	protocol.MessageBase
+	Point Point
+}
+
+func NewMsgReAcquire(point Point) *MsgReAcquire {
+	m := &MsgReAcquire{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_REACQUIRE,
+		},
+		Point: point,
+	}
+	return m
+}
+
+type MsgReAcquireNoPoint struct {
+	protocol.MessageBase
+}
+
+func NewMsgReAcquireNoPoint() *MsgReAcquireNoPoint {
+	m := &MsgReAcquireNoPoint{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_REACQUIRE_NO_POINT,
+		},
+	}
+	return m
+}
+
+type MsgDone struct {
+	protocol.MessageBase
+}
+
+func NewMsgDone() *MsgDone {
+	m := &MsgDone{
+		MessageBase: protocol.MessageBase{
+			MessageType: MESSAGE_TYPE_DONE,
+		},
+	}
+	return m
+}
+
+type Point struct {
+	Slot uint64
+	Hash []byte
+}
+
+// A "point" can sometimes be empty, but the CBOR library gets grumpy about this
+// when doing automatic decoding from an array, so we have to handle this case specially
+func (p *Point) UnmarshalCBOR(data []byte) error {
+	var tmp []interface{}
+	if err := cbor.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) > 0 {
+		p.Slot = tmp[0].(uint64)
+		p.Hash = tmp[1].([]byte)
+	}
+	return nil
+}


### PR DESCRIPTION
This implements all of the messages and state machine, but there's no
test program, query/result definitions, or helper functions for sending
messages.

This is part of #10