### PR TITLE
fix: Babbage block parsing

### DIFF
--- a/cmd/go-ouroboros-network/chainsync.go
+++ b/cmd/go-ouroboros-network/chainsync.go
@@ -74,7 +74,7 @@ var eraIntersect = map[string]map[string][]interface{}{
 		"genesis": []interface{}{},
 		"alonzo":  []interface{}{},
 		// Last block of epoch 3 (Alonzo era)
-		"babbage": []interface{}{345599, "6e4de9c9b2dcc2436488aa8a6ce584250a45b42583c5d3d0749597bcf59dc0b5"},
+		"babbage": []interface{}{345594, "e47ac07272e95d6c3dc8279def7b88ded00e310f99ac3dfbae48ed9ff55e6001"},
 	},
 }
 

--- a/ledger/mary.go
+++ b/ledger/mary.go
@@ -63,8 +63,7 @@ func (h *MaryBlockHeader) Era() Era {
 
 type MaryTransactionBody struct {
 	AllegraTransactionBody
-	//Outputs []MaryTransactionOutput `cbor:"1,keyasint,omitempty"`
-	Outputs []cbor.Value `cbor:"1,keyasint,omitempty"`
+	Outputs []MaryTransactionOutput `cbor:"1,keyasint,omitempty"`
 	// TODO: further parsing of this field
 	Mint cbor.Value `cbor:"9,keyasint,omitempty"`
 }
@@ -85,9 +84,12 @@ type MaryTransaction struct {
 transaction_output = [address, amount : value]
 value = coin / [coin,multiasset<uint>]
 */
-//type MaryTransactionOutput interface{}
 
-type MaryTransactionOutput cbor.Value
+type MaryTransactionOutput struct {
+	cbor.StructAsArray
+	Address Blake2b256
+	Amount  cbor.Value
+}
 
 func NewMaryBlockFromCbor(data []byte) (*MaryBlock, error) {
 	var maryBlock MaryBlock


### PR DESCRIPTION
* don't try to parse arbitrary plutus scripts/data
* add missing transaction witness set field
* better support alternate transaction output format
* update Babbage intersect point for preview in test program

Fixes #204