### PR TITLE
fix: store block type/CBOR in MsgRollForwardNtC

### DIFF
--- a/cbor/cbor.go
+++ b/cbor/cbor.go
@@ -1,11 +1,7 @@
 package cbor
 
 import (
-	"fmt"
-	"reflect"
-
 	_cbor "github.com/fxamacker/cbor/v2"
-	"github.com/jinzhu/copier"
 )
 
 const (
@@ -46,32 +42,9 @@ func (d *DecodeStoreCbor) Cbor() []byte {
 	return d.cborData
 }
 
-// UnmarshalCborGeneric decodes the specified CBOR into the destination object without using the
-// destination object's UnmarshalCBOR() function
-func (d *DecodeStoreCbor) UnmarshalCborGeneric(cborData []byte, dest DecodeStoreCborInterface) error {
-	// Create a duplicate(-ish) struct from the destination
-	// We do this so that we can bypass any custom UnmarshalCBOR() function on the
-	// destination object
-	valueDest := reflect.ValueOf(dest)
-	if valueDest.Kind() != reflect.Pointer || valueDest.Elem().Kind() != reflect.Struct {
-		return fmt.Errorf("destination must be a pointer to a struct")
-	}
-	typeDestElem := valueDest.Elem().Type()
-	destTypeFields := []reflect.StructField{}
-	for i := 0; i < typeDestElem.NumField(); i++ {
-		tmpField := typeDestElem.Field(i)
-		if tmpField.IsExported() && tmpField.Name != "DecodeStoreCbor" {
-			destTypeFields = append(destTypeFields, tmpField)
-		}
-	}
-	// Create temporary object with the type created above
-	tmpDest := reflect.New(reflect.StructOf(destTypeFields))
-	// Decode CBOR into temporary object
-	if _, err := Decode(cborData, tmpDest.Interface()); err != nil {
-		return err
-	}
-	// Copy values from temporary object into destination object
-	if err := copier.Copy(dest, tmpDest.Interface()); err != nil {
+// UnmarshalCbor decodes the specified CBOR into the destination object and saves the original CBOR
+func (d *DecodeStoreCbor) UnmarshalCbor(cborData []byte, dest DecodeStoreCborInterface) error {
+	if err := DecodeGeneric(cborData, dest); err != nil {
 		return err
 	}
 	// Store a copy of the original CBOR data

--- a/ledger/allegra.go
+++ b/ledger/allegra.go
@@ -26,7 +26,7 @@ type AllegraBlock struct {
 }
 
 func (b *AllegraBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 func (b *AllegraBlock) Hash() string {
@@ -69,7 +69,7 @@ type AllegraTransactionBody struct {
 }
 
 func (b *AllegraTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 type AllegraTransaction struct {
@@ -82,7 +82,7 @@ type AllegraTransaction struct {
 func NewAllegraBlockFromCbor(data []byte) (*AllegraBlock, error) {
 	var allegraBlock AllegraBlock
 	if _, err := cbor.Decode(data, &allegraBlock); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Allegra block decode error: %s", err)
 	}
 	return &allegraBlock, nil
 }
@@ -90,7 +90,7 @@ func NewAllegraBlockFromCbor(data []byte) (*AllegraBlock, error) {
 func NewAllegraTransactionBodyFromCbor(data []byte) (*AllegraTransactionBody, error) {
 	var allegraTx AllegraTransactionBody
 	if _, err := cbor.Decode(data, &allegraTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Allegra transaction body decode error: %s", err)
 	}
 	return &allegraTx, nil
 }
@@ -98,7 +98,7 @@ func NewAllegraTransactionBodyFromCbor(data []byte) (*AllegraTransactionBody, er
 func NewAllegraTransactionFromCbor(data []byte) (*AllegraTransaction, error) {
 	var allegraTx AllegraTransaction
 	if _, err := cbor.Decode(data, &allegraTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Allegra transaction decode error: %s", err)
 	}
 	return &allegraTx, nil
 }

--- a/ledger/alonzo.go
+++ b/ledger/alonzo.go
@@ -27,7 +27,7 @@ type AlonzoBlock struct {
 }
 
 func (b *AlonzoBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 func (b *AlonzoBlock) Hash() string {
@@ -74,7 +74,7 @@ type AlonzoTransactionBody struct {
 }
 
 func (b *AlonzoTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 type AlonzoTransactionOutput struct {
@@ -93,7 +93,7 @@ func (o *AlonzoTransactionOutput) UnmarshalCBOR(cborData []byte) error {
 		o.Address = tmpOutput.Address
 		o.Amount = tmpOutput.Amount
 	} else {
-		return o.UnmarshalCborGeneric(cborData, o)
+		return o.UnmarshalCbor(cborData, o)
 	}
 	return nil
 }
@@ -116,7 +116,7 @@ type AlonzoTransaction struct {
 func NewAlonzoBlockFromCbor(data []byte) (*AlonzoBlock, error) {
 	var alonzoBlock AlonzoBlock
 	if _, err := cbor.Decode(data, &alonzoBlock); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Alonzo block decode error: %s", err)
 	}
 	return &alonzoBlock, nil
 }
@@ -124,7 +124,7 @@ func NewAlonzoBlockFromCbor(data []byte) (*AlonzoBlock, error) {
 func NewAlonzoTransactionBodyFromCbor(data []byte) (*AlonzoTransactionBody, error) {
 	var alonzoTx AlonzoTransactionBody
 	if _, err := cbor.Decode(data, &alonzoTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Alonzo transaction body decode error: %s", err)
 	}
 	return &alonzoTx, nil
 }
@@ -132,7 +132,7 @@ func NewAlonzoTransactionBodyFromCbor(data []byte) (*AlonzoTransactionBody, erro
 func NewAlonzoTransactionFromCbor(data []byte) (*AlonzoTransaction, error) {
 	var alonzoTx AlonzoTransaction
 	if _, err := cbor.Decode(data, &alonzoTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Alonzo transaction decode error: %s", err)
 	}
 	return &alonzoTx, nil
 }

--- a/ledger/babbage.go
+++ b/ledger/babbage.go
@@ -27,7 +27,7 @@ type BabbageBlock struct {
 }
 
 func (b *BabbageBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 func (b *BabbageBlock) Hash() string {
@@ -87,7 +87,7 @@ type BabbageBlockHeader struct {
 }
 
 func (h *BabbageBlockHeader) UnmarshalCBOR(cborData []byte) error {
-	return h.UnmarshalCborGeneric(cborData, h)
+	return h.UnmarshalCbor(cborData, h)
 }
 
 func (h *BabbageBlockHeader) Hash() string {
@@ -118,11 +118,10 @@ type BabbageTransactionBody struct {
 }
 
 func (b *BabbageTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 type BabbageTransactionOutput struct {
-	cbor.DecodeStoreCbor
 	Address      Blake2b256        `cbor:"0,keyasint,omitempty"`
 	Amount       cbor.Value        `cbor:"1,keyasint,omitempty"`
 	DatumOption  []cbor.RawMessage `cbor:"2,keyasint,omitempty"`
@@ -139,7 +138,7 @@ func (o *BabbageTransactionOutput) UnmarshalCBOR(cborData []byte) error {
 		o.Amount = tmpOutput.Amount
 		o.legacyOutput = true
 	} else {
-		return o.UnmarshalCborGeneric(cborData, o)
+		return cbor.DecodeGeneric(cborData, o)
 	}
 	return nil
 }
@@ -160,7 +159,7 @@ type BabbageTransaction struct {
 func NewBabbageBlockFromCbor(data []byte) (*BabbageBlock, error) {
 	var babbageBlock BabbageBlock
 	if _, err := cbor.Decode(data, &babbageBlock); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Babbage block decode error: %s", err)
 	}
 	return &babbageBlock, nil
 }
@@ -168,7 +167,7 @@ func NewBabbageBlockFromCbor(data []byte) (*BabbageBlock, error) {
 func NewBabbageBlockHeaderFromCbor(data []byte) (*BabbageBlockHeader, error) {
 	var babbageBlockHeader BabbageBlockHeader
 	if _, err := cbor.Decode(data, &babbageBlockHeader); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Babbage block header decode error: %s", err)
 	}
 	return &babbageBlockHeader, nil
 }
@@ -176,7 +175,7 @@ func NewBabbageBlockHeaderFromCbor(data []byte) (*BabbageBlockHeader, error) {
 func NewBabbageTransactionBodyFromCbor(data []byte) (*BabbageTransactionBody, error) {
 	var babbageTx BabbageTransactionBody
 	if _, err := cbor.Decode(data, &babbageTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Babbage transaction body decode error: %s", err)
 	}
 	return &babbageTx, nil
 }
@@ -184,7 +183,7 @@ func NewBabbageTransactionBodyFromCbor(data []byte) (*BabbageTransactionBody, er
 func NewBabbageTransactionFromCbor(data []byte) (*BabbageTransaction, error) {
 	var babbageTx BabbageTransaction
 	if _, err := cbor.Decode(data, &babbageTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Babbage transaction decode error: %s", err)
 	}
 	return &babbageTx, nil
 }

--- a/ledger/byron.go
+++ b/ledger/byron.go
@@ -58,7 +58,7 @@ type ByronMainBlockHeader struct {
 }
 
 func (h *ByronMainBlockHeader) UnmarshalCBOR(cborData []byte) error {
-	return h.UnmarshalCborGeneric(cborData, h)
+	return h.UnmarshalCbor(cborData, h)
 }
 
 func (h *ByronMainBlockHeader) Hash() string {
@@ -117,7 +117,7 @@ type ByronEpochBoundaryBlockHeader struct {
 }
 
 func (h *ByronEpochBoundaryBlockHeader) UnmarshalCBOR(cborData []byte) error {
-	return h.UnmarshalCborGeneric(cborData, h)
+	return h.UnmarshalCbor(cborData, h)
 }
 
 func (h *ByronEpochBoundaryBlockHeader) Hash() string {
@@ -153,7 +153,7 @@ type ByronMainBlock struct {
 }
 
 func (b *ByronMainBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 func (b *ByronMainBlock) Hash() string {
@@ -186,7 +186,7 @@ type ByronEpochBoundaryBlock struct {
 }
 
 func (b *ByronEpochBoundaryBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 func (b *ByronEpochBoundaryBlock) Hash() string {
@@ -213,7 +213,7 @@ func (b *ByronEpochBoundaryBlock) Transactions() []TransactionBody {
 func NewByronEpochBoundaryBlockFromCbor(data []byte) (*ByronEpochBoundaryBlock, error) {
 	var byronEbbBlock ByronEpochBoundaryBlock
 	if _, err := cbor.Decode(data, &byronEbbBlock); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Byron EBB block decode error: %s", err)
 	}
 	return &byronEbbBlock, nil
 }
@@ -221,7 +221,7 @@ func NewByronEpochBoundaryBlockFromCbor(data []byte) (*ByronEpochBoundaryBlock, 
 func NewByronEpochBoundaryBlockHeaderFromCbor(data []byte) (*ByronEpochBoundaryBlockHeader, error) {
 	var byronEbbBlockHeader ByronEpochBoundaryBlockHeader
 	if _, err := cbor.Decode(data, &byronEbbBlockHeader); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Byron EBB block header decode error: %s", err)
 	}
 	return &byronEbbBlockHeader, nil
 }
@@ -229,7 +229,7 @@ func NewByronEpochBoundaryBlockHeaderFromCbor(data []byte) (*ByronEpochBoundaryB
 func NewByronMainBlockFromCbor(data []byte) (*ByronMainBlock, error) {
 	var byronMainBlock ByronMainBlock
 	if _, err := cbor.Decode(data, &byronMainBlock); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Byron main block decode error: %s", err)
 	}
 	return &byronMainBlock, nil
 }
@@ -237,7 +237,7 @@ func NewByronMainBlockFromCbor(data []byte) (*ByronMainBlock, error) {
 func NewByronMainBlockHeaderFromCbor(data []byte) (*ByronMainBlockHeader, error) {
 	var byronMainBlockHeader ByronMainBlockHeader
 	if _, err := cbor.Decode(data, &byronMainBlockHeader); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Byron main block header decode error: %s", err)
 	}
 	return &byronMainBlockHeader, nil
 }
@@ -245,7 +245,7 @@ func NewByronMainBlockHeaderFromCbor(data []byte) (*ByronMainBlockHeader, error)
 func NewByronTransactionBodyFromCbor(data []byte) (*ByronTransactionBody, error) {
 	var byronTx ByronTransactionBody
 	if _, err := cbor.Decode(data, &byronTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Byron transaction body decode error: %s", err)
 	}
 	return &byronTx, nil
 }
@@ -253,7 +253,7 @@ func NewByronTransactionBodyFromCbor(data []byte) (*ByronTransactionBody, error)
 func NewByronTransactionFromCbor(data []byte) (*ByronTransaction, error) {
 	var byronTx ByronTransaction
 	if _, err := cbor.Decode(data, &byronTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Byron transaction decode error: %s", err)
 	}
 	return &byronTx, nil
 }

--- a/ledger/mary.go
+++ b/ledger/mary.go
@@ -26,7 +26,7 @@ type MaryBlock struct {
 }
 
 func (b *MaryBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 func (b *MaryBlock) Hash() string {
@@ -71,7 +71,7 @@ type MaryTransactionBody struct {
 }
 
 func (b *MaryTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 type MaryTransaction struct {
@@ -96,7 +96,7 @@ type MaryTransactionOutput struct {
 func NewMaryBlockFromCbor(data []byte) (*MaryBlock, error) {
 	var maryBlock MaryBlock
 	if _, err := cbor.Decode(data, &maryBlock); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Mary block decode error: %s", err)
 	}
 	return &maryBlock, nil
 }
@@ -104,7 +104,7 @@ func NewMaryBlockFromCbor(data []byte) (*MaryBlock, error) {
 func NewMaryTransactionBodyFromCbor(data []byte) (*MaryTransactionBody, error) {
 	var maryTx MaryTransactionBody
 	if _, err := cbor.Decode(data, &maryTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Mary transaction body decode error: %s", err)
 	}
 	return &maryTx, nil
 }
@@ -112,7 +112,7 @@ func NewMaryTransactionBodyFromCbor(data []byte) (*MaryTransactionBody, error) {
 func NewMaryTransactionFromCbor(data []byte) (*MaryTransaction, error) {
 	var maryTx MaryTransaction
 	if _, err := cbor.Decode(data, &maryTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Mary transaction decode error: %s", err)
 	}
 	return &maryTx, nil
 }

--- a/ledger/shelley.go
+++ b/ledger/shelley.go
@@ -26,7 +26,7 @@ type ShelleyBlock struct {
 }
 
 func (b *ShelleyBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 func (b *ShelleyBlock) Hash() string {
@@ -81,7 +81,7 @@ type ShelleyBlockHeader struct {
 }
 
 func (h *ShelleyBlockHeader) UnmarshalCBOR(cborData []byte) error {
-	return h.UnmarshalCborGeneric(cborData, h)
+	return h.UnmarshalCbor(cborData, h)
 }
 
 func (h *ShelleyBlockHeader) Hash() string {
@@ -125,7 +125,7 @@ type ShelleyTransactionBody struct {
 }
 
 func (b *ShelleyTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCborGeneric(cborData, b)
+	return b.UnmarshalCbor(cborData, b)
 }
 
 func (b *ShelleyTransactionBody) Hash() string {
@@ -163,7 +163,7 @@ type ShelleyTransaction struct {
 func NewShelleyBlockFromCbor(data []byte) (*ShelleyBlock, error) {
 	var shelleyBlock ShelleyBlock
 	if _, err := cbor.Decode(data, &shelleyBlock); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Shelley block decode error: %s", err)
 	}
 	return &shelleyBlock, nil
 }
@@ -171,7 +171,7 @@ func NewShelleyBlockFromCbor(data []byte) (*ShelleyBlock, error) {
 func NewShelleyBlockHeaderFromCbor(data []byte) (*ShelleyBlockHeader, error) {
 	var shelleyBlockHeader ShelleyBlockHeader
 	if _, err := cbor.Decode(data, &shelleyBlockHeader); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Shelley block header decode error: %s", err)
 	}
 	return &shelleyBlockHeader, nil
 }
@@ -179,7 +179,7 @@ func NewShelleyBlockHeaderFromCbor(data []byte) (*ShelleyBlockHeader, error) {
 func NewShelleyTransactionBodyFromCbor(data []byte) (*ShelleyTransactionBody, error) {
 	var shelleyTx ShelleyTransactionBody
 	if _, err := cbor.Decode(data, &shelleyTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Shelley transaction body decode error: %s", err)
 	}
 	return &shelleyTx, nil
 }
@@ -187,7 +187,7 @@ func NewShelleyTransactionBodyFromCbor(data []byte) (*ShelleyTransactionBody, er
 func NewShelleyTransactionFromCbor(data []byte) (*ShelleyTransaction, error) {
 	var shelleyTx ShelleyTransaction
 	if _, err := cbor.Decode(data, &shelleyTx); err != nil {
-		return nil, fmt.Errorf("decode error: %s", err)
+		return nil, fmt.Errorf("Shelley transaction decode error: %s", err)
 	}
 	return &shelleyTx, nil
 }


### PR DESCRIPTION
This also changes the following:

* rearrange generic CBOR parsing utility to be able to be used separately from storing the CBOR
* better ledger decode error messages